### PR TITLE
Make Maybe Just Again

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "coveralls": "^3.0.2",
     "cross-env": "^5.2.0",
     "cz-conventional-changelog": "^2.1.0",
-    "fast-check": "^2.5.0",
+    "fast-check": "^1.16.0",
     "fp-ts-laws": "^0.2.1",
     "handlebars": "4.5.0",
     "husky": "^1.0.1",

--- a/src/what-is-a-monad-ts.ts
+++ b/src/what-is-a-monad-ts.ts
@@ -6,20 +6,25 @@ import { Monad1 } from 'fp-ts/lib/Monad'
 // property-tests
 import { Arbitrary, constant, oneof } from 'fast-check'
 
-// TODO: why I cannot call this "Maybe"?? 😭
-const URI = 'Option'
+const URI = 'Maybe'
 type URI = typeof URI
 
 interface Nothing {
-  readonly _tag: 'None'
+  readonly _tag: 'Nothing'
 }
 
 interface Just<A> {
-  readonly _tag: 'Some'
+  readonly _tag: 'Just'
   readonly value: A
 }
 
 type Maybe<A> = Nothing | Just<A>
+
+declare module 'fp-ts/lib/HKT' {
+  interface URItoKind<A> {
+    readonly [URI]: Maybe<A>
+  }
+}
 
 /**
  * The `Monad` type class combines the operations of the `Chain` and
@@ -37,13 +42,13 @@ type Maybe<A> = Nothing | Just<A>
  */
 
 // @ts-ignore
-const isJust = <A>(fa: Maybe<A>): fa is Just<A> => fa._tag === 'Some'
-const isNothing = <A>(fa: Maybe<A>): fa is Nothing => fa._tag === 'None'
+const isJust = <A>(fa: Maybe<A>): fa is Just<A> => fa._tag === 'Just'
+const isNothing = <A>(fa: Maybe<A>): fa is Nothing => fa._tag === 'Nothing'
 
 // construtors
 
-const nothing: Maybe<never> = { _tag: 'None' }
-const just = <A>(a: A): Maybe<A> => ({ _tag: 'Some', value: a })
+export const nothing: Maybe<never> = { _tag: 'Nothing' }
+export const just = <A>(a: A): Maybe<A> => ({ _tag: 'Just', value: a })
 
 // operations
 
@@ -63,7 +68,8 @@ export const getEq = <A>(E: Eq<A>): Eq<Maybe<A>> => ({
     x === y || (isNothing(x) ? isNothing(y) : isNothing(y) ? false : E.equals(x.value, y.value))
 })
 
-export const getOption = <A>(arb: Arbitrary<A>) => oneof(getNothing(), getJust(arb))
+export const getMaybe = <A>(arb: Arbitrary<A>): Arbitrary<Maybe<A>> =>
+  oneof(getNothing<A>(), getJust(arb))
 
 // instances of Arbitrary for fast-check
 

--- a/src/what-is-a-monad-ts.ts
+++ b/src/what-is-a-monad-ts.ts
@@ -68,8 +68,7 @@ export const getEq = <A>(E: Eq<A>): Eq<Maybe<A>> => ({
     x === y || (isNothing(x) ? isNothing(y) : isNothing(y) ? false : E.equals(x.value, y.value))
 })
 
-export const getMaybe = <A>(arb: Arbitrary<A>): Arbitrary<Maybe<A>> =>
-  oneof(getNothing<A>(), getJust(arb))
+export const getMaybe = <A>(arb: Arbitrary<A>) => oneof(getNothing<A>(), getJust(arb))
 
 // instances of Arbitrary for fast-check
 

--- a/test/what-is-a-monad-ts.test.ts
+++ b/test/what-is-a-monad-ts.test.ts
@@ -1,16 +1,14 @@
 import { applicative, functor, monad } from 'fp-ts-laws'
 
-import { maybe, getEq, getOption } from '../src/what-is-a-monad-ts'
+import { maybe, getEq, getMaybe } from '../src/what-is-a-monad-ts'
 
 describe('My custom Monad', () => {
-  // FIXME: 'getOption' should work
   it('should test Functor laws', () => {
-    functor(maybe)(getOption, getEq)
+    functor(maybe)(getMaybe, getEq)
   })
 
-  // FIXME: 'getOption' should work
   it('should test Applicative laws', () => {
-    applicative(maybe)(getOption, getEq)
+    applicative(maybe)(getMaybe, getEq)
   })
 
   it('should test Monad laws', () => {


### PR DESCRIPTION
1. https://github.com/gcanti/fp-ts-laws/blob/master/package.json#L33
This matters because of invariance. Error message was like `Arbitrary<A> is not an Arbitrary<A>`
2. Nothing requires a type parameter in this case
3. `declare module` == `please, believe me, everything's gonna be safe`